### PR TITLE
Added SkippingReason field in the `SkippedTasks` field of `PipelineRunStatus`.

### DIFF
--- a/pkg/apis/pipeline/v1beta1/openapi_generated.go
+++ b/pkg/apis/pipeline/v1beta1/openapi_generated.go
@@ -3330,6 +3330,14 @@ func schema_pkg_apis_pipeline_v1beta1_SkippedTask(ref common.ReferenceCallback) 
 							Format:      "",
 						},
 					},
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Reason is the cause of the PipelineTask being skipped.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"whenExpressions": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -3350,7 +3358,7 @@ func schema_pkg_apis_pipeline_v1beta1_SkippedTask(ref common.ReferenceCallback) 
 						},
 					},
 				},
-				Required: []string{"name"},
+				Required: []string{"name", "reason"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -484,11 +484,35 @@ type PipelineRunStatusFields struct {
 type SkippedTask struct {
 	// Name is the Pipeline Task name
 	Name string `json:"name"`
+	// Reason is hte cause of the PipelineTask being skipped.
+	Reason SkippingReason `json: "reason"`
 	// WhenExpressions is the list of checks guarding the execution of the PipelineTask
 	// +optional
 	// +listType=atomic
 	WhenExpressions []WhenExpression `json:"whenExpressions,omitempty"`
 }
+
+// SkippingReason explains why a PipelineTask was skiped.
+type SkippingReason string
+
+const (
+	// WhenExpressionsSkip means the task was skipped due to at least one of its when expressions evaluating to false
+	WhenExpressionsSkip SkippingReason = "WhenExpressionsSkip"
+	// ConditionsSkip means the task was skipped due to at least one of its conditions failing
+	ConditionsSkip SkippingReason = "ConditionsSkip"
+	// ParentTasksSkip means the task was skipped because its parent was skipped
+	ParentTasksSkip SkippingReason = "ParentTasksSkip"
+	// IsStoppingSkip means the task was skipped because the pipeline run is stopping
+	IsStoppingSkip SkippingReason = "IsStoppingSkip"
+	// IsGracefullyCancelledSkip means the task was skipped because the pipeline run has been gracefully cancelled
+	IsGracefullyCancelledSkip SkippingReason = "IsGracefullyCancelledSkip"
+	// IsGracefullyStoppedSkip means the task was skipped because the pipeline run has been gracefully stopped
+	IsGracefullyStoppedSkip SkippingReason = "IsGracefullyStoppedSkip"
+	// MissingResultsSkip means the task was skipped because it's missing necessary results
+	MissingResultsSkip SkippingReason = "MissingResultsSkip"
+	// None means the task was not skipped
+	None SkippingReason = "None"
+)
 
 // PipelineRunResult used to describe the results of a pipeline
 type PipelineRunResult struct {

--- a/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
+++ b/pkg/apis/pipeline/v1beta1/pipelinerun_types.go
@@ -484,8 +484,8 @@ type PipelineRunStatusFields struct {
 type SkippedTask struct {
 	// Name is the Pipeline Task name
 	Name string `json:"name"`
-	// Reason is hte cause of the PipelineTask being skipped.
-	Reason SkippingReason `json: "reason"`
+	// Reason is the cause of the PipelineTask being skipped.
+	Reason SkippingReason `json:"reason"`
 	// WhenExpressions is the list of checks guarding the execution of the PipelineTask
 	// +optional
 	// +listType=atomic

--- a/pkg/apis/pipeline/v1beta1/swagger.json
+++ b/pkg/apis/pipeline/v1beta1/swagger.json
@@ -1883,11 +1883,17 @@
       "description": "SkippedTask is used to describe the Tasks that were skipped due to their When Expressions evaluating to False. This is a struct because we are looking into including more details about the When Expressions that caused this Task to be skipped.",
       "type": "object",
       "required": [
-        "name"
+        "name",
+        "reason"
       ],
       "properties": {
         "name": {
           "description": "Name is the Pipeline Task name",
+          "type": "string",
+          "default": ""
+        },
+        "reason": {
+          "description": "Reason is the cause of the PipelineTask being skipped.",
           "type": "string",
           "default": ""
         },

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -39,28 +39,6 @@ const (
 	ReasonConditionCheckFailed = "ConditionCheckFailed"
 )
 
-// SkippingReason explains why a task was skipped
-// type SkippingReason string
-
-// const (
-// 	// WhenExpressionsSkip means the task was skipped due to at least one of its when expressions evaluating to false
-// 	WhenExpressionsSkip SkippingReason = "WhenExpressionsSkip"
-// 	// ConditionsSkip means the task was skipped due to at least one of its conditions failing
-// 	ConditionsSkip SkippingReason = "ConditionsSkip"
-// 	// ParentTasksSkip means the task was skipped because its parent was skipped
-// 	ParentTasksSkip SkippingReason = "ParentTasksSkip"
-// 	// IsStoppingSkip means the task was skipped because the pipeline run is stopping
-// 	IsStoppingSkip SkippingReason = "IsStoppingSkip"
-// 	// IsGracefullyCancelledSkip means the task was skipped because the pipeline run has been gracefully cancelled
-// 	IsGracefullyCancelledSkip SkippingReason = "IsGracefullyCancelledSkip"
-// 	// IsGracefullyStoppedSkip means the task was skipped because the pipeline run has been gracefully stopped
-// 	IsGracefullyStoppedSkip SkippingReason = "IsGracefullyStoppedSkip"
-// 	// MissingResultsSkip means the task was skipped because it's missing necessary results
-// 	MissingResultsSkip SkippingReason = "MissingResultsSkip"
-// 	// None means the task was not skipped
-// 	None SkippingReason = "None"
-// )
-
 // TaskSkipStatus stores whether a task was skipped and why
 type TaskSkipStatus struct {
 	IsSkipped      bool

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go
@@ -40,31 +40,31 @@ const (
 )
 
 // SkippingReason explains why a task was skipped
-type SkippingReason string
+// type SkippingReason string
 
-const (
-	// WhenExpressionsSkip means the task was skipped due to at least one of its when expressions evaluating to false
-	WhenExpressionsSkip SkippingReason = "WhenExpressionsSkip"
-	// ConditionsSkip means the task was skipped due to at least one of its conditions failing
-	ConditionsSkip SkippingReason = "ConditionsSkip"
-	// ParentTasksSkip means the task was skipped because its parent was skipped
-	ParentTasksSkip SkippingReason = "ParentTasksSkip"
-	// IsStoppingSkip means the task was skipped because the pipeline run is stopping
-	IsStoppingSkip SkippingReason = "IsStoppingSkip"
-	// IsGracefullyCancelledSkip means the task was skipped because the pipeline run has been gracefully cancelled
-	IsGracefullyCancelledSkip SkippingReason = "IsGracefullyCancelledSkip"
-	// IsGracefullyStoppedSkip means the task was skipped because the pipeline run has been gracefully stopped
-	IsGracefullyStoppedSkip SkippingReason = "IsGracefullyStoppedSkip"
-	// MissingResultsSkip means the task was skipped because it's missing necessary results
-	MissingResultsSkip SkippingReason = "MissingResultsSkip"
-	// None means the task was not skipped
-	None SkippingReason = "None"
-)
+// const (
+// 	// WhenExpressionsSkip means the task was skipped due to at least one of its when expressions evaluating to false
+// 	WhenExpressionsSkip SkippingReason = "WhenExpressionsSkip"
+// 	// ConditionsSkip means the task was skipped due to at least one of its conditions failing
+// 	ConditionsSkip SkippingReason = "ConditionsSkip"
+// 	// ParentTasksSkip means the task was skipped because its parent was skipped
+// 	ParentTasksSkip SkippingReason = "ParentTasksSkip"
+// 	// IsStoppingSkip means the task was skipped because the pipeline run is stopping
+// 	IsStoppingSkip SkippingReason = "IsStoppingSkip"
+// 	// IsGracefullyCancelledSkip means the task was skipped because the pipeline run has been gracefully cancelled
+// 	IsGracefullyCancelledSkip SkippingReason = "IsGracefullyCancelledSkip"
+// 	// IsGracefullyStoppedSkip means the task was skipped because the pipeline run has been gracefully stopped
+// 	IsGracefullyStoppedSkip SkippingReason = "IsGracefullyStoppedSkip"
+// 	// MissingResultsSkip means the task was skipped because it's missing necessary results
+// 	MissingResultsSkip SkippingReason = "MissingResultsSkip"
+// 	// None means the task was not skipped
+// 	None SkippingReason = "None"
+// )
 
 // TaskSkipStatus stores whether a task was skipped and why
 type TaskSkipStatus struct {
 	IsSkipped      bool
-	SkippingReason SkippingReason
+	SkippingReason v1beta1.SkippingReason
 }
 
 // TaskNotFoundError indicates that the resolution failed because a referenced Task couldn't be retrieved
@@ -231,31 +231,31 @@ func (t *ResolvedPipelineRunTask) checkParentsDone(facts *PipelineRunFacts) bool
 }
 
 func (t *ResolvedPipelineRunTask) skip(facts *PipelineRunFacts) TaskSkipStatus {
-	var skippingReason SkippingReason
+	var skippingReason v1beta1.SkippingReason
 
 	switch {
 	case facts.isFinalTask(t.PipelineTask.Name) || t.IsStarted():
-		skippingReason = None
+		skippingReason = v1beta1.None
 	case facts.IsStopping():
-		skippingReason = IsStoppingSkip
+		skippingReason = v1beta1.IsStoppingSkip
 	case facts.IsGracefullyCancelled():
-		skippingReason = IsGracefullyCancelledSkip
+		skippingReason = v1beta1.IsGracefullyCancelledSkip
 	case facts.IsGracefullyStopped():
-		skippingReason = IsGracefullyStoppedSkip
+		skippingReason = v1beta1.IsGracefullyStoppedSkip
 	case t.skipBecauseParentTaskWasSkipped(facts):
-		skippingReason = ParentTasksSkip
+		skippingReason = v1beta1.ParentTasksSkip
 	case t.skipBecauseConditionsFailed():
-		skippingReason = ConditionsSkip
+		skippingReason = v1beta1.ConditionsSkip
 	case t.skipBecauseResultReferencesAreMissing(facts):
-		skippingReason = MissingResultsSkip
+		skippingReason = v1beta1.MissingResultsSkip
 	case t.skipBecauseWhenExpressionsEvaluatedToFalse(facts):
-		skippingReason = WhenExpressionsSkip
+		skippingReason = v1beta1.WhenExpressionsSkip
 	default:
-		skippingReason = None
+		skippingReason = v1beta1.None
 	}
 
 	return TaskSkipStatus{
-		IsSkipped:      skippingReason != None,
+		IsSkipped:      skippingReason != v1beta1.None,
 		SkippingReason: skippingReason,
 	}
 }
@@ -312,7 +312,7 @@ func (t *ResolvedPipelineRunTask) skipBecauseParentTaskWasSkipped(facts *Pipelin
 		if parentSkipStatus := parentTask.Skip(facts); parentSkipStatus.IsSkipped {
 			// if the parent task was skipped due to its `when` expressions,
 			// then we should ignore that and continue evaluating if we should skip because of other parent tasks
-			if parentSkipStatus.SkippingReason == WhenExpressionsSkip {
+			if parentSkipStatus.SkippingReason == v1beta1.WhenExpressionsSkip {
 				continue
 			}
 			return true
@@ -327,7 +327,7 @@ func (t *ResolvedPipelineRunTask) skipBecauseResultReferencesAreMissing(facts *P
 	if t.checkParentsDone(facts) && t.hasResultReferences() {
 		resolvedResultRefs, pt, err := ResolveResultRefs(facts.State, PipelineRunState{t})
 		rprt := facts.State.ToMap()[pt]
-		if err != nil && (t.IsFinalTask(facts) || rprt.Skip(facts).SkippingReason == WhenExpressionsSkip) {
+		if err != nil && (t.IsFinalTask(facts) || rprt.Skip(facts).SkippingReason == v1beta1.WhenExpressionsSkip) {
 			return true
 		}
 		ApplyTaskResults(PipelineRunState{t}, resolvedResultRefs)
@@ -343,26 +343,26 @@ func (t *ResolvedPipelineRunTask) IsFinalTask(facts *PipelineRunFacts) bool {
 
 // IsFinallySkipped returns true if a finally task is not executed and skipped due to task result validation failure
 func (t *ResolvedPipelineRunTask) IsFinallySkipped(facts *PipelineRunFacts) TaskSkipStatus {
-	var skippingReason SkippingReason
+	var skippingReason v1beta1.SkippingReason
 
 	switch {
 	case t.IsStarted():
-		skippingReason = None
+		skippingReason = v1beta1.None
 	case facts.checkDAGTasksDone() && facts.isFinalTask(t.PipelineTask.Name):
 		switch {
 		case t.skipBecauseResultReferencesAreMissing(facts):
-			skippingReason = MissingResultsSkip
+			skippingReason = v1beta1.MissingResultsSkip
 		case t.skipBecauseWhenExpressionsEvaluatedToFalse(facts):
-			skippingReason = WhenExpressionsSkip
+			skippingReason = v1beta1.WhenExpressionsSkip
 		default:
-			skippingReason = None
+			skippingReason = v1beta1.None
 		}
 	default:
-		skippingReason = None
+		skippingReason = v1beta1.None
 	}
 
 	return TaskSkipStatus{
-		IsSkipped:      skippingReason != None,
+		IsSkipped:      skippingReason != v1beta1.None,
 		SkippingReason: skippingReason,
 	}
 

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate.go
@@ -556,17 +556,19 @@ func (facts *PipelineRunFacts) GetSkippedTasks() []v1beta1.SkippedTask {
 		if rprt.Skip(facts).IsSkipped {
 			skippedTask := v1beta1.SkippedTask{
 				Name:            rprt.PipelineTask.Name,
+				Reason:          rprt.Skip(facts).SkippingReason,
 				WhenExpressions: rprt.PipelineTask.WhenExpressions,
 			}
 			skipped = append(skipped, skippedTask)
 		}
 		if rprt.IsFinallySkipped(facts).IsSkipped {
 			skippedTask := v1beta1.SkippedTask{
-				Name: rprt.PipelineTask.Name,
+				Name:   rprt.PipelineTask.Name,
+				Reason: rprt.IsFinallySkipped(facts).SkippingReason,
 			}
 			// include the when expressions only when the finally task was skipped because
 			// its when expressions evaluated to false (not because results variables were missing)
-			if rprt.IsFinallySkipped(facts).SkippingReason == WhenExpressionsSkip {
+			if rprt.IsFinallySkipped(facts).SkippingReason == v1beta1.WhenExpressionsSkip {
 				skippedTask.WhenExpressions = rprt.PipelineTask.WhenExpressions
 			}
 			skipped = append(skipped, skippedTask)

--- a/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
+++ b/pkg/reconciler/pipelinerun/resources/pipelinerunstate_test.go
@@ -1890,7 +1890,8 @@ func TestPipelineRunFacts_GetSkippedTasks(t *testing.T) {
 		dagTasks:     []v1beta1.PipelineTask{pts[0]},
 		finallyTasks: []v1beta1.PipelineTask{pts[14]},
 		expectedSkippedTasks: []v1beta1.SkippedTask{{
-			Name: pts[14].Name,
+			Name:   pts[14].Name,
+			Reason: v1beta1.MissingResultsSkip,
 		}},
 	}, {
 		name: "when-expressions-skip-finally",
@@ -1899,7 +1900,8 @@ func TestPipelineRunFacts_GetSkippedTasks(t *testing.T) {
 		}},
 		finallyTasks: []v1beta1.PipelineTask{pts[10]},
 		expectedSkippedTasks: []v1beta1.SkippedTask{{
-			Name: pts[10].Name,
+			Name:   pts[10].Name,
+			Reason: v1beta1.WhenExpressionsSkip,
 			WhenExpressions: []v1beta1.WhenExpression{{
 				Input:    "foo",
 				Operator: "notin",


### PR DESCRIPTION
To address the [TEP](https://github.com/tektoncd/community/blob/main/teps/0103-skipping-reason.md) and [issue](https://github.com/tektoncd/pipeline/issues/4738).
Skipping Reason included in the `SkippedTasks` field of `PipelineRunStatus`.

Prior to this, users only knew that a `PipelineTask` was skipped but not
the exact reason for skipping the task leading to confusion when
debugging `Pipelines`.

This commit adds a field `Reason` of type [`SkippingReason`](https://github.com/tektoncd/pipeline/blob/053833cb10f3829d5a366daa1f431b293dcf3285/pkg/reconciler/pipelinerun/resources/pipelinerunresolution.go#L42-L62) (a string alias) to the [`SkippedTasks`](https://github.com/tektoncd/pipeline/blob/053833cb10f3829d5a366daa1f431b293dcf3285/pkg/apis/pipeline/v1beta1/pipelinerun_types.go#L466-L476)field in `PipelineRunStatus`. The tests have been updated to validate skipping reason.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from your descriptive commit message(s)! 

In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: bug, cleanup, design, documentation, feature, flake, misc, question, tep
-->

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [ ] [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) included if any changes are user facing
- [x] [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including
  functionality, content, code)
- [ ] Release notes block below has been filled in
(if there are no user facing changes, use release note "NONE")

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
